### PR TITLE
Add touch support (only)

### DIFF
--- a/Sources/GlowGetter/SwiftUI+GlowOverlay.swift
+++ b/Sources/GlowGetter/SwiftUI+GlowOverlay.swift
@@ -21,6 +21,7 @@ public extension View {
         let glowView = GlowRenderView()
             .blendMode(.multiply)
             .opacity(intensity)
+            .allowsHitTesting(false)
 
         return self.overlay(content: {
             if let clipShape = clipShape {


### PR DESCRIPTION
Currently, the `.glow()` modifier prevents any interactive element in the view from being touched.
This PR simply adds a `.allowsHitTesting(false)` to the GlowRenderView, that fixes this bug.

To reproduce:

```
import SwiftUI
import GlowGetter

struct ContentView: View {
    @State var isShowingAlert = false
    var body: some View {
        VStack {
            VStack {
                Text("Without HDR")
                tester()
            }
            .frame(maxHeight: .infinity)
            
            VStack {
                Text("With HDR (GlowGetter)")
                tester().glow(1, RoundedRectangle(cornerRadius: 24))
            }
            .frame(maxHeight: .infinity)
        }
        .padding()
        
        .alert("It works!", isPresented: $isShowingAlert) {
            Button("Dismiss") {}
        }
    }
    
    @ViewBuilder
    func tester() -> some View {
        RoundedRectangle(cornerRadius: 24)
            .fill(Color.yellow.gradient)
            .overlay {
                Button("Tap me") { isShowingAlert = true }
                    .buttonStyle(.borderedProminent)
                    .buttonBorderShape(.capsule)
            }
    }
}

#Preview {
    ContentView()
}
```