### PR TITLE
Change deprecated "Obfuscate" dependency to "SwiftMacros"

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
         .target(
             name: "GlowGetterPrivate",
             dependencies: [
-                .product(name: "Obfuscate", package: "Obfuscate")
+                .product(name: "SwiftMacros", package: "SwiftMacros")
             ]),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
             targets: ["GlowGetterPrivate"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/Aeastr/Obfuscate.git", from: "1.0.0")
+        .package(url: "https://github.com/Aeastr/SwiftMacros.git", from: "1.0.0")
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
             targets: ["GlowGetterPrivate"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/Aeastr/SwiftMacros.git", from: "1.0.0")
+        .package(url: "https://github.com/Aeastr/SwiftMacros.git", from: "0.3.1")
     ],
     targets: [
         .target(

--- a/Sources/GlowGetterPrivate/CAFilter.swift
+++ b/Sources/GlowGetterPrivate/CAFilter.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 import SwiftUI
-import Obfuscate
+import SwiftMacros
 
 // MARK: - Obfuscated Strings
 


### PR DESCRIPTION
I encountered an error when compiling my app that uses GlowGetter, and it may have something to do with Obfuscate deprecation. Let me know if I'm missing something or if you're not having the same issue.